### PR TITLE
fix suden crash

### DIFF
--- a/Plant/SAMUCA-Sugarcane/SC_SAMUCA_MODEL.f90
+++ b/Plant/SAMUCA-Sugarcane/SC_SAMUCA_MODEL.f90
@@ -3150,7 +3150,7 @@ subroutine SAMUCA(CONTROL, ISWITCH,                                 &
     acc_par     =   acc_par  +  dacc_par
     
     !--- Calculated RUE
-    if((acc_par .gt. z) .and. (ddw .gt. z))then
+    if((acc_par .gt. z) .and. (ddw .gt. z) .and. (dacc_par .gt. z))then
         drue_calc   = (ddw        * 1.e6/1.e4) / dacc_par ! RUE based on daily biomass gain and PAR intercepted [gDW/MJ]
         rue_calc    = (dw_total   * 1.e6/1.e4) / acc_par  ! RUE based on accumulated biomass and accumulated PAR intercepted [gDW/MJ] (the "typical" way)
     endif


### PR DESCRIPTION
---

Hi @chporter ,

I found that SAMUCA suddenly crashes due to an accidental zero division when running the Xfile: 

~/DSSAT47/Sugarcane/UFBG0501.SCX

I have fixed this minor issue in this commit, so please consider merging it.

---

The same issue also happens with CANEGRO. As far as I could test here, this is also due to the same problem (e.g. when ETC = 0) in:

https://github.com/chporter/dssat-csm-os/blob/0e74b6a0e134c49382b3f60f86029bacdb76005b/Plant/CANEGRO-Sugarcane/SC_CCOUT.for#L224

Please consider fixing it in a near future too =)

---